### PR TITLE
Change exception type to general java SQLException

### DIFF
--- a/src/main/scala/com/metamx/common/scala/db/DB.scala
+++ b/src/main/scala/com/metamx/common/scala/db/DB.scala
@@ -195,7 +195,7 @@ abstract class DB(config: DBConfig) extends Logging {
       }
     }
 
-    def exists(table: String) = !raises[StatementException] { select("select * from %s limit 0" format table) }
+    def exists(table: String) = !raises[java.sql.SQLException] { select("select * from %s limit 0" format table) }
 
   }
 


### PR DESCRIPTION
Was causing issues for me with a local MYSQL DB with a fresh DB and no tables.

Ideally Skife would have caught the error, I find it odd that it didn't.
