### PR TITLE
update http-client to fix runtime error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "com.metamx" % "java-util" % "0.27.4" force(),
-  "com.metamx" % "http-client" % "1.0.0" force(),
+  "com.metamx" % "http-client" % "1.0.2" force(),
   "com.metamx" % "emitter" % "0.3.0" force(),
   "com.metamx" % "server-metrics" % "0.2.5" force()
 )

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.netty" % "netty" % "3.10.1.Final" force()
+  "io.netty" % "netty" % "3.10.4.Final" force()
 )
 
 //


### PR DESCRIPTION
- http-client 1.0.0 calls deprecated methods in netty, which broke when updating netty
- upgrade netty while we're at it