### PR TITLE
Update to Jackson 2.6.6.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ releaseSettings
 
 ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value
 
-val jacksonFasterxmlVersion = "2.6.0"
+val jacksonFasterxmlVersion = "2.6.6"
 val curatorVersion = "2.10.0"
 val zookeeperVersion = "3.4.8"
 val twittersVersion = "6.31.0"


### PR DESCRIPTION
Should help with a couple issues people have run into with Jackson 2.6.0. Not jumping to 2.7.x right now, just because 2.6.6 is going to be compatible with 2.6.x but 2.7.x might not be.

- https://github.com/FasterXML/jackson-core/issues/216
- https://github.com/FasterXML/jackson-module-scala/issues/214#issuecomment-122699036 is also concerning:

> IMPORTANT NOTE: Version 2.6.0 was incorrectly released and should not be used.