### PR TITLE
Update common metamx libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ scala:
    - 2.10.5
    - 2.11.7
 
+script:
+   - sbt ++$TRAVIS_SCALA_VERSION --debug test
+
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -71,9 +71,9 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.metamx" % "java-util" % "0.27.4" force(),
-  "com.metamx" % "http-client" % "1.0.3" force(),
-  "com.metamx" % "emitter" % "0.3.3" force(),
+  "com.metamx" % "java-util" % "0.27.11" force(),
+  "com.metamx" % "http-client" % "1.0.5" force(),
+  "com.metamx" % "emitter" % "0.3.6" force(),
   "com.metamx" % "server-metrics" % "0.2.10" force()
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ libraryDependencies ++= Seq(
   "com.metamx" % "java-util" % "0.27.4" force(),
   "com.metamx" % "http-client" % "1.0.3" force(),
   "com.metamx" % "emitter" % "0.3.3" force(),
-  "com.metamx" % "server-metrics" % "0.2.8" force()
+  "com.metamx" % "server-metrics" % "0.2.10" force()
 )
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Updates 4 common metamx libs: java-utils, http-client, emitter and server-metrics, to the latest versions, available on Maven.

Change in Travis CI build (`sbt --debug`) config apparently helped to flush some sbt's cache, because without this change sbt (actually Ivy) was failing to find recently released `server-metrics:0.2.10` in repos. I think it's OK to leave this as a regular config, because I cannot see any harm from this.
