### PR TITLE
upgrading finagle version to 6.35.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value
 val jacksonFasterxmlVersion = "2.6.6"
 val curatorVersion = "2.10.0"
 val zookeeperVersion = "3.4.8"
-val twittersVersion = "6.31.0"
+val twittersVersion = "6.35.0"
 val twitterUtilsVersion = "6.30.0"
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/com/metamx/common/scala/net/finagle/DiscoResolver.scala
+++ b/src/main/scala/com/metamx/common/scala/net/finagle/DiscoResolver.scala
@@ -3,12 +3,14 @@ package com.metamx.common.scala.net.finagle
 import com.metamx.common.lifecycle.Lifecycle
 import com.metamx.common.scala.Logging
 import com.metamx.common.scala.net.curator.Disco
-import com.twitter.finagle.{Addr, Resolver}
+import com.twitter.finagle.{Addr, Address, Resolver}
 import com.twitter.util.{Closable, Future, Time, Var}
 import java.net.{InetSocketAddress, SocketAddress}
+
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.state.ConnectionState
 import org.apache.curator.x.discovery.details.ServiceCacheListener
+
 import scala.collection.JavaConverters._
 
 /**
@@ -27,8 +29,8 @@ class DiscoResolver(disco: Disco) extends Resolver with Logging
       def doUpdate() {
         val newInstances = serviceCache.getInstances.asScala.toSet
         log.info("Updating instances for service[%s] to %s", service, newInstances)
-        val newSocketAddresses: Set[SocketAddress] = newInstances map
-          (instance => new InetSocketAddress(instance.getAddress, instance.getPort))
+        val newSocketAddresses: Set[Address] = newInstances map
+          (instance => Address(new InetSocketAddress(instance.getAddress, instance.getPort)))
         updatable.update(Addr.Bound(newSocketAddresses))
       }
       serviceCache.addListener(

--- a/src/main/scala/com/metamx/common/scala/net/finagle/InetAddressResolver.scala
+++ b/src/main/scala/com/metamx/common/scala/net/finagle/InetAddressResolver.scala
@@ -3,7 +3,7 @@ package com.metamx.common.scala.net.finagle
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.metamx.common.scala.Logging
 import com.twitter.finagle.util.{DefaultTimer, InetSocketAddressUtil}
-import com.twitter.finagle.{Addr, Resolver}
+import com.twitter.finagle.{Addr, Address, Resolver}
 import com.twitter.util.{Closable, Future, FuturePool, Timer, Var, Duration => TwitterDuration}
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
@@ -47,7 +47,7 @@ class InetAddressResolver(ttl: TwitterDuration, futurePool: FuturePool, timer: T
       }
   }
 
-  private def resolveString(arg: String) = Addr.Bound(InetSocketAddressUtil.parseHosts(arg): _*)
+  private def resolveString(arg: String) = Addr.Bound(InetSocketAddressUtil.parseHosts(arg).map(Address(_)): _*)
 }
 
 object InetAddressResolver


### PR DESCRIPTION
Upgrading finagle version to 6.35.0. We use tranquility for druid in our organization **Tapad**.  Tranquility uses scala-utils as a dependency. Scala-utils uses 6.31.0 version of finagle which is not compatible to some of our organization's services. So we request you to upgrade finagle's version to 6.35.0.